### PR TITLE
Fix Liquid conditional in reveal.js config template

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -8,7 +8,7 @@
   // https://github.com/hakimel/reveal.js#configuration
   Reveal.initialize({
     {% if site.reveal %}
-    {% for attr in site.reveal %}{{attr[0]}}: {% unless {attr[1]} == false or {attr[1]} == true or {attr[0]} == "width" or {attr[0]} == "height" %}'{{attr[1]}}',{% else %}{{attr[1]}},{% endunless %}
+    {% for attr in site.reveal %}{{attr[0]}}: {% unless attr[1] == false or attr[1] == true or attr[0] == "width" or attr[0] == "height" %}'{{attr[1]}}',{% else %}{{attr[1]}},{% endunless %}
     {% endfor %}
     {% endif %}
 


### PR DESCRIPTION
### Motivation
- Fix a Liquid syntax bug in the reveal.js configuration template so site `reveal` options are evaluated correctly and option quoting is emitted as intended.

### Description
- Replace `{attr[1]}` with `attr[1]` inside the `unless` conditional in `_includes/script.html` so the condition compares the actual attribute value instead of a literal string.

### Testing
- Ran `bundle exec jekyll build --baseurl "."` to validate the site build; the command failed in this environment because the `jekyll` executable is not available via Bundler (`bundler: command not found: jekyll`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c9b0060c8333a4a4aab6ecb14aec)